### PR TITLE
Fix typo in twitter metatag

### DIFF
--- a/source/partials/_event_meta.html.erb
+++ b/source/partials/_event_meta.html.erb
@@ -6,6 +6,6 @@
 <meta name="twitter:image" content="<%= asset_url :images, 'flag.jpg' %>" />
 
 <meta property="og:url"                content="http://empex.co/" />
-<meta property="og:title"              content="EMEPX - <%= event.title %>" />
+<meta property="og:title"              content="EMPEX - <%= event.title %>" />
 <meta property="og:description"        content="<%= description %>" />
 <meta property="og:image" content="<%= asset_url :images, 'flag.jpg' %>" />


### PR DESCRIPTION
Just noticed this typo while sharing the CFP announcement on twitter. Hope planning is going well!